### PR TITLE
[Doc] Follow updated default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Git utility script to delete merged local branches.
 # Installation
 
 ```
-curl -O https://raw.githubusercontent.com/kyanny/git-delete-merged-branches/master/git-delete-merged-branches
+curl -O https://raw.githubusercontent.com/kyanny/git-delete-merged-branches/main/git-delete-merged-branches
 chmod +x git-delete-merged-branches
 install git-delete-merged-branches /usr/local/bin
 rm git-delete-merged-branches


### PR DESCRIPTION
I don't know the detail of GitHub behavios.
`master` branch looks renamed to `main`. But I can access same file.
Is it a forwarding feature in GitHub?
 
<img width="883" alt="スクリーンショット 2021-04-04 11 41 14" src="https://user-images.githubusercontent.com/1180335/113497058-ece4ee00-953a-11eb-802e-8f4b221794db.png">


<img width="590" alt="スクリーンショット 2021-04-04 11 41 00" src="https://user-images.githubusercontent.com/1180335/113497057-eb1b2a80-953a-11eb-85ac-d6f55ebcf8ce.png">

But I think update to `main` from `master` does not make confusions for someone like me. So I have created this PR 😄 
