### PR TITLE
Correct ERE to consider prefix patterns

### DIFF
--- a/git-delete-merged-branches
+++ b/git-delete-merged-branches
@@ -7,4 +7,4 @@
 #   $ git config --global --add alias.fp '!git fetch -p && git-delete-merged-branches'
 #   $ git config --global --add alias.pp '!git pull -p && git-delete-merged-branches'
 
-git branch --merged | grep -vE '^\*|main$|master$|develop$' | xargs -I % git branch -d %
+git branch --merged | grep -vE '((^\*)|^ *(main|master|develop)$)' | xargs -I % git branch -d %


### PR DESCRIPTION
My environment is below.

```console
$ git --version
git version 2.30.0
$ grep --version
grep (BSD grep) 2.5.1-FreeBSD
$ ggrep --version
ggrep (GNU grep) 3.6
Packaged by Homebrew
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Mike Haertel and others; see
<https://git.sv.gnu.org/cgit/grep.git/tree/AUTHORS>.

$ git branch -a
* current_branch
  develop
  develop-foo
  foo
  foo-develop
  foo-main
  foo-master
  main
  main-foo
  master
  master-foo

$ git branch -a | xargs -I % git rev-parse %
* current_branch
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b
9c82d5ed3e243b591626aef91474d10e9b29a80b

$ git branch --merged
* current_branch
  develop
  develop-foo
  foo
  foo-develop
  foo-main
  foo-master
  main
  main-foo
  master
  master-foo
```

Before this change. The filtering excludes `special name with prefix` patterns. Is this an intentional behavior?

```console
$ git branch --merged | grep -vE '^\*|main$|master$|develop$'
  develop-foo
  foo
  main-foo
  master-foo
$ git branch --merged | ggrep -vE '^\*|main$|master$|develop$'
  develop-foo
  foo
  main-foo
  master-foo
```

After this change, they will be included.

```console
$ git branch --merged | grep -vE '((^\*)|^ *(main|master|develop)$)'
  develop-foo
  foo
  foo-develop
  foo-main
  foo-master
  main-foo
  master-foo
$ git branch --merged | ggrep -vE '((^\*)|^ *(main|master|develop)$)'
  develop-foo
  foo
  foo-develop
  foo-main
  foo-master
  main-foo
  master-foo
```