### PR TITLE
Cover git suggested default branches

### DIFF
--- a/git-delete-merged-branches
+++ b/git-delete-merged-branches
@@ -7,4 +7,4 @@
 #   $ git config --global --add alias.fp '!git fetch -p && git-delete-merged-branches'
 #   $ git config --global --add alias.pp '!git pull -p && git-delete-merged-branches'
 
-git branch --merged | grep -vE '^\*|main$|master$|develop$' | xargs -I % git branch -d %
+git branch --merged | grep -vE '((^\*)|^ *(main|master|develop)$)' | xargs -I % git branch -d %

--- a/git-delete-merged-branches
+++ b/git-delete-merged-branches
@@ -7,4 +7,4 @@
 #   $ git config --global --add alias.fp '!git fetch -p && git-delete-merged-branches'
 #   $ git config --global --add alias.pp '!git pull -p && git-delete-merged-branches'
 
-git branch --merged | grep -vE '((^\*)|^ *(main|master|develop)$)' | xargs -I % git branch -d %
+git branch --merged | grep -vE '((^\*)|^ *(main|master|develop|development|trunk)$)' | xargs -I % git branch -d %


### PR DESCRIPTION
This PR based on https://github.com/kyanny/git-delete-merged-branches/pull/5.

https://github.com/git/git/blob/142430338477d9d1bb25be66267225fb58498d92/refs.c#L565-L576

```c
static const char default_branch_name_advice[] = N_(
"Using '%s' as the name for the initial branch. This default branch name\n"
"is subject to change. To configure the initial branch name to use in all\n"
"of your new repositories, which will suppress this warning, call:\n"
"\n"
"\tgit config --global init.defaultBranch <name>\n"
"\n"
"Names commonly chosen instead of 'master' are 'main', 'trunk' and\n"
"'development'. The just-created branch can be renamed via this command:\n"
"\n"
"\tgit branch -m <name>\n"
);
```

git suggested `development` and `trunk` are a default branches.
I know the one is `ruby` it used `trunk` as the default branch before https://bugs.ruby-lang.org/issues/14632 and https://bugs.ruby-lang.org/issues/15782.
They already renamed to master. But it still suggested in git.

How about to add them?